### PR TITLE
Update minimum tested Rust version to 1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - libdw-dev
       - binutils-dev
 rust:
-  - 1.15.1
+  - 1.17.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This is a library that allows an easy implementation of a
 - Crate Documentation: https://coredump-ch.github.io/spaceapi-server-rs/
 - Space API Reference: http://spaceapi.net/documentation
 
+## Requirements
+
+ * Rust 1.17.0 or newer
+
 
 ## Usage
 


### PR DESCRIPTION
Due to a breaking changes in dependencies we need to bump the minimum
tested Rust version to 1.17.0