### PR TITLE
Bump minimal required Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - libdw-dev
       - binutils-dev
 rust:
-  - 1.17.0
+  - 1.21.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a library that allows an easy implementation of a
 
 ## Requirements
 
- * Rust 1.17.0 or newer
+ * Rust 1.21.0 or newer
 
 
 ## Usage


### PR DESCRIPTION
The unicode-normalization crate requires a newer Rust version.