### PR TITLE
Replace error-type macro with quick-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ log = "^0.3"
 iron = "^0.5"
 urlencoded = "^0.5"
 router = "^0.5"
-error-type = "^0.1"
 serde = "^1.0"
 serde_json = "^1.0"
 spaceapi = "^0.5.0"
+quick-error = "1.2"
+
 
 [dev-dependencies]
 env_logger = "^0.4"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,4 @@
 //! Custom error types.
-//!
-//! Unfortunately we can only define one error type using the ``error_type!`` macro in here, see
-//! https://github.com/DanielKeep/rust-error-type/issues/2.
 
 use redis::RedisError;
 use r2d2::InitializationError;
@@ -10,22 +7,25 @@ use std::borrow::Cow;
 
 
 /// A ``SpaceapiServerError`` wraps general problems that can occur in the SpaceAPI server.
-error_type! {
+quick_error! {
     #[derive(Debug)]
     pub enum SpaceapiServerError {
-        Redis(RedisError) {
-            cause;
-        },
-        R2d2(InitializationError) {
-            cause;
-        },
-        IoError(io::Error) {
-            cause;
-        },
-        Message(Cow<'static, str>) {
-            desc (e) &**e;
-            from (s: &'static str) s.into();
-            from (s: String) s.into();
-        },
+        Redis(err: RedisError) {
+            from()
+            cause(err)
+        }
+        R2d2(err: InitializationError) {
+            from()
+            cause(err)
+        }
+        IoError(err: io::Error) {
+            from()
+            cause(err)
+        }
+        Message(err: Cow<'static, str>) {
+            description(&**err)
+            from(s: &'static str) -> (s.into())
+            from(s: String) -> (s.into())
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![doc(html_root_url = "https://docs.rs/spaceapi-server")]
 
 #[macro_use] extern crate log;
-#[macro_use] extern crate error_type;
+#[macro_use] extern crate quick_error;
 extern crate serde;
 extern crate serde_json;
 extern crate iron;

--- a/src/sensors.rs
+++ b/src/sensors.rs
@@ -18,20 +18,22 @@ pub struct SensorSpec {
     pub data_key: String,
 }
 
-error_type! {
+quick_error! {
     /// A ``SensorError`` wraps problems that can occur when reading or updating sensor values.
     ///
     /// This type is only used for internal purposes and should not be used by third party code.
     #[derive(Debug)]
     pub enum SensorError {
-        UnknownSensor(String) {
-            desc (sensor) &sensor;
-        },
-        Redis(RedisError) {
-            cause;
-        },
-        R2d2(r2d2::GetTimeout) {
-            cause;
+        UnknownSensor(err: String) {
+            description(err)
+        }
+        Redis(err: RedisError) {
+            from()
+            cause(err)
+        }
+        R2d2(err: r2d2::GetTimeout) {
+            from()
+            cause(err)
         }
     }
 }


### PR DESCRIPTION
error-type was last updated in 2015 and is not compatible with the 2018 edition.

https://docs.rs/quick-error/1.2.2/quick_error/