### PR TITLE
Bump Rust to 1.36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   test:
     docker:
-      - image: rust:1.31
+      - image: rust:1.36
     steps:
       - checkout
       - restore_cache:
@@ -31,7 +31,7 @@ jobs:
             - /usr/local/cargo
   lint:
     docker:
-      - image: rust:1.31
+      - image: rust:1.36
     steps:
       - checkout
       - restore_cache:
@@ -45,7 +45,7 @@ jobs:
             - /usr/local/cargo
   fmt:
     docker:
-      - image: rust:1.31
+      - image: rust:1.36
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Possible log types:
 
 ### Unreleased
 
+- [changed] Do not guarantee a fixed MSRV anymore (#99)
 - [changed] Bump dependencies, including spaceapi which now uses an enum for
   the `issue_report_channels` see the [spaceapi changelog] for more details
   (#92, #97)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,22 @@
 This is a library that allows an easy implementation of a
 [SpaceAPI](https://spaceapi.io/) v0.13 server in Rust.
 
-- Crate Documentation: https://docs.rs/spaceapi-server/
-- Space API Reference: https://spaceapi.io/pages/docs.html
+ * Crate Documentation: https://docs.rs/spaceapi-server/
+ * Space API Reference: https://spaceapi.io/pages/docs.html
 
 
 ## Requirements
 
- * Rust 1.31 or newer
  * A Redis instance on the server
+
+
+## Rust Version Requirements (MSRV)
+
+This library generally tracks the latest stable Rust version but tries to
+guarantee backwards compatibility with older stable versions as much as
+possible. However, in many cases transitive dependencies make guaranteeing a
+minimal supported Rust version impossible (see [this
+discussion](https://users.rust-lang.org/t/rust-version-requirement-change-as-semver-breaking-or-not/20980/25)).
 
 
 ## Usage


### PR DESCRIPTION
Bump Rust version to 1.36, update MSRV guarantees.

## Checklist

- [x] Tests added if applicable
- [x] README updated if applicable
- [x] CHANGELOG updated if applicable
- [x] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message