### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   test:
     docker:
-      - image: rust:1.60
+      - image: rust:1.63
     steps:
       - checkout
       - restore_cache:
@@ -31,7 +31,7 @@ jobs:
             - /usr/local/cargo
   lint:
     docker:
-      - image: rust:1.60
+      - image: rust:1.63
     steps:
       - checkout
       - restore_cache:
@@ -45,7 +45,7 @@ jobs:
             - /usr/local/cargo
   fmt:
     docker:
-      - image: rust:1.60
+      - image: rust:1.63
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Possible log types:
 ### Unreleased
 
 - [changed] Update spaceapi to 0.9. See [spaceapi changelog] for more details.
+- [changed] Bump MSRV to 1.63
 
 ### v0.7.0 (2023-04-19)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
     "LICENSE-APACHE",
 ]
 edition = "2021"
-rust = "1.60"
+rust = "1.63"
 
 [dependencies]
 r2d2 = "^0.8.7"


### PR DESCRIPTION
The dependency rustix requires it.

<!--- Explain your issue / bug / feature -->

## Checklist

- [na] Tests added if applicable
- [na] README updated if applicable
- [X] CHANGELOG updated if applicable
- [na] If a commit includes a breaking change, include the string `[breaking-change]` somewhere in the commit message
